### PR TITLE
Add messaging & user tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ Once connected, ask your AI client things like:
 - *"What homes have I favourited?"*
 - *"Show the availability calendar for home 1950607"*
 
-**14 tools across two categories:**
+**20 tools across three categories:**
 
 | Category | Tools |
 |----------|-------|
-| 🔍 **Search & discovery** | `search_homes` · `get_home` · `get_home_calendar` · `get_recommendations` · `list_my_homes` · `list_favorites` · `add_favorite` · `remove_favorite` · `list_saved_searches` · `get_user_profile` |
-| 💬 **Messaging** | `list_conversations` · `get_conversation` · `send_message` · `start_conversation` |
+| 🔍 **Search & discovery** | `search_homes` · `get_home` · `get_home_calendar` · `get_recommendations` · `list_my_homes` · `list_favorites` · `add_favorite` · `remove_favorite` · `list_saved_searches` |
+| 💬 **Messaging** | `list_conversations` · `get_conversation` · `get_messages` · `get_exchange_request` · `send_message` · `start_conversation` · `pre_approve_exchange` · `archive_conversation` |
+| 👤 **Users** | `get_user_profile` · `get_user_ratings` · `get_user_achievements` |
 
 ---
 
@@ -50,12 +51,13 @@ Once connected, ask your AI client things like:
        │
   MCP Server (local, stdio)
        │
-  ┌────┴──────────────────────┐
-  │                           │
-  search & discovery     messaging
-  (10 tools)             (4 tools)
-       │                      │
-       └─────────┬────────────┘
+  ┌────┴──────────────────────────────┐
+  │                 │                 │
+  search &       messaging          users
+  discovery      (8 tools)        (3 tools)
+  (9 tools)          │                │
+       │             └────────┬───────┘
+       └────────────────┘
                  │
      api.homeexchange.com
      bff.homeexchange.com
@@ -220,13 +222,6 @@ Your saved search filters.
 |-----------|------|----------|---------|-------------|
 | `limit` | number | No | `100` | Number of results |
 
-#### `get_user_profile`
-A member's public profile.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `user_id` | string | **Yes** | Numeric user ID |
-
 ---
 
 ### 💬 Messaging
@@ -241,7 +236,21 @@ Your conversation inbox.
 | `after` | string | No | — | Pagination cursor from previous response |
 
 #### `get_conversation`
-All messages in a thread.
+Extended information about a conversation, including exchange details.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `conversation_id` | string | **Yes** | Conversation ID |
+
+#### `get_messages`
+All messages in a conversation thread.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `conversation_id` | string | **Yes** | Conversation ID |
+
+#### `get_exchange_request`
+Exchange request details attached to a conversation.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -262,6 +271,45 @@ Open a new conversation about a home.
 |-----------|------|----------|-------------|
 | `home_id` | string | **Yes** | The home you're enquiring about |
 | `text` | string | **Yes** | Opening message |
+
+#### `pre_approve_exchange`
+Pre-approve an exchange request.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `conversation_id` | string | **Yes** | Conversation ID |
+
+#### `archive_conversation`
+Archive a conversation.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `conversation_id` | string | **Yes** | Conversation ID |
+
+---
+
+### 👤 Users
+
+#### `get_user_profile`
+A member's public profile.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | **Yes** | Numeric user ID |
+
+#### `get_user_ratings`
+Ratings left for a member.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | **Yes** | Numeric user ID |
+
+#### `get_user_achievements`
+Achievements earned by a member.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | **Yes** | Numeric user ID |
 
 ---
 
@@ -288,8 +336,9 @@ src/
   api.ts            authenticated HTTP client
   mcp.ts            MCP stdio server
   tools/
-    search.ts       10 search & discovery tools
-    messaging.ts    4 messaging tools
+    search.ts       9 search & discovery tools
+    messaging.ts    8 messaging tools
+    user.ts         3 user tools
 ```
 
 ---

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -56,6 +56,22 @@ describe('api client', () => {
     });
   });
 
+  it('supports BFF PATCH requests with optional bodies and parameters', async () => {
+    await api.bffPatch('/exchange/123/pre-approve', { approved: true }, { locale: 'en' });
+    await api.bffPatch('/v1/conversations/123/archive');
+
+    const [firstUrl, firstInit] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(firstUrl.toString()).toBe('https://bff.homeexchange.com/exchange/123/pre-approve?locale=en');
+    expect(firstInit).toMatchObject({
+      method: 'PATCH',
+      body: JSON.stringify({ approved: true }),
+    });
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      method: 'PATCH',
+      body: undefined,
+    });
+  });
+
   it('supports API writes and deletes', async () => {
     await api.post('/v1/messages', { content: 'hello' });
     await api.del('/v1/messages/123');

--- a/src/api.ts
+++ b/src/api.ts
@@ -89,7 +89,7 @@ export const api = {
   bffPatch<T>(endpoint: string, body?: unknown, params?: Record<string, string>): Promise<T> {
     const url = new URL(`https://bff.homeexchange.com${endpoint}`);
     if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
-    return request<T>(url.toString(), { method: 'PATCH', body: body ? JSON.stringify(body) : undefined });
+    return request<T>(url, { method: 'PATCH', body: body ? JSON.stringify(body) : undefined });
   },
 
   get<T>(endpoint: string, params?: Record<string, string>): Promise<T> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -34,6 +34,7 @@ function baseHeaders(): Record<string, string> {
   return {
     'Content-Type': 'application/json',
     Accept: 'application/json',
+    'Accept-Language': 'en',
     ...(session.token ? { Authorization: session.token } : {}),
     Cookie: cookieHeader(),
   };

--- a/src/api.ts
+++ b/src/api.ts
@@ -85,6 +85,12 @@ export const api = {
     return request<T>(url, { method: 'POST', body: JSON.stringify(body) });
   },
 
+  bffPatch<T>(endpoint: string, body?: unknown, params?: Record<string, string>): Promise<T> {
+    const url = new URL(`https://bff.homeexchange.com${endpoint}`);
+    if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+    return request<T>(url.toString(), { method: 'PATCH', body: body ? JSON.stringify(body) : undefined });
+  },
+
   get<T>(endpoint: string, params?: Record<string, string>): Promise<T> {
     const url = new URL(`https://api.homeexchange.com${endpoint}`);
     if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -7,10 +7,12 @@ import {
 
 import { searchTools, handleSearch } from './tools/search';
 import { messagingTools, handleMessaging } from './tools/messaging';
+import { userTools, handleUser } from './tools/user';
 
-const ALL_TOOLS = [...searchTools, ...messagingTools];
+const ALL_TOOLS = [...searchTools, ...messagingTools, ...userTools];
 const SEARCH_NAMES = new Set(searchTools.map((t) => t.name));
 const MESSAGING_NAMES = new Set(messagingTools.map((t) => t.name));
+const USER_NAMES = new Set(userTools.map((t) => t.name));
 
 const server = new Server(
   { name: 'homeexchange', version: '1.0.0' },
@@ -31,6 +33,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       result = await handleSearch(name, args as Record<string, unknown>);
     } else if (MESSAGING_NAMES.has(name)) {
       result = await handleMessaging(name, args as Record<string, unknown>);
+    } else if (USER_NAMES.has(name)) {
+      result = await handleUser(name, args as Record<string, unknown>);
     } else {
       throw new Error(`Unknown tool: ${name}`);
     }

--- a/src/tools/messaging.ts
+++ b/src/tools/messaging.ts
@@ -127,10 +127,10 @@ export async function handleMessaging(name: string, args: Args): Promise<unknown
       return api.bff('/v3/messages', { conversation_id: args['conversation_id'] as string });
 
     case 'send_message':
-      return api.bffPost(
-        `/v3/conversations/${args['conversation_id'] as string}/messages`,
-        { text: args['text'] }
-      );
+      return api.bffPost('/v1/messages', {
+        content: args['text'],
+        conversation: Number(args['conversation_id']),
+      });
 
     case 'start_conversation':
       return api.bffPost('/v3/conversations', {

--- a/src/tools/messaging.ts
+++ b/src/tools/messaging.ts
@@ -14,13 +14,13 @@ export const messagingTools: Tool[] = [
           description: 'Filter conversations (default ALL)',
         },
         limit: { type: 'number', description: 'Number to return (default 20)' },
-        after:  { type: 'string', description: 'Pagination cursor (from previous response)' },
+        after: { type: 'string', description: 'Pagination cursor (from previous response)' },
       },
     },
   },
   {
     name: 'get_conversation',
-    description: 'Get all messages in a conversation thread.',
+    description: 'Get extended information about a conversation.',
     inputSchema: {
       type: 'object',
       required: ['conversation_id'],
@@ -42,6 +42,17 @@ export const messagingTools: Tool[] = [
     },
   },
   {
+    name: 'get_messages',
+    description: 'Get all messages of a conversation.',
+    inputSchema: {
+      type: 'object',
+      required: ['conversation_id'],
+      properties: {
+        conversation_id: { type: 'string', description: 'Conversation ID' },
+      },
+    },
+  },
+  {
     name: 'start_conversation',
     description: 'Start a new conversation with a member about their home.',
     inputSchema: {
@@ -49,7 +60,7 @@ export const messagingTools: Tool[] = [
       required: ['home_id', 'text'],
       properties: {
         home_id: { type: 'string', description: 'The home you are enquiring about' },
-        text:    { type: 'string', description: 'Opening message' },
+        text: { type: 'string', description: 'Opening message' },
       },
     },
   },
@@ -61,14 +72,17 @@ export async function handleMessaging(name: string, args: Args): Promise<unknown
   switch (name) {
     case 'list_conversations': {
       const filter = (args['filter'] as string | undefined) ?? 'ALL';
-      const limit  = (args['limit']  as number | undefined) ?? 20;
+      const limit = (args['limit'] as number | undefined) ?? 20;
       const params: Record<string, string> = { filter, first: String(limit) };
       if (args['after'] !== undefined) params['after'] = args['after'] as string;
       return api.bff('/v3/conversations/me', params);
     }
 
     case 'get_conversation':
-      return api.bff(`/v3/conversations/${args['conversation_id'] as string}`);
+      return api.bff(`/v3/conversations/me/${args['conversation_id'] as string}`);
+
+    case 'get_messages':
+      return api.bff('/v3/messages', { conversation_id: args['conversation_id'] as string });
 
     case 'send_message':
       return api.bffPost(

--- a/src/tools/messaging.ts
+++ b/src/tools/messaging.ts
@@ -42,8 +42,41 @@ export const messagingTools: Tool[] = [
     },
   },
   {
+    name: 'get_exchange_request',
+    description: 'Get exchange request details for a conversation.',
+    inputSchema: {
+      type: 'object',
+      required: ['conversation_id'],
+      properties: {
+        conversation_id: { type: 'string', description: 'Conversation ID' },
+      },
+    },
+  },
+  {
     name: 'get_messages',
     description: 'Get all messages of a conversation.',
+    inputSchema: {
+      type: 'object',
+      required: ['conversation_id'],
+      properties: {
+        conversation_id: { type: 'string', description: 'Conversation ID' },
+      },
+    },
+  },
+  {
+    name: 'pre_approve_exchange',
+    description: 'Pre-approve an exchange request.',
+    inputSchema: {
+      type: 'object',
+      required: ['conversation_id'],
+      properties: {
+        conversation_id: { type: 'string', description: 'Conversation ID' },
+      },
+    },
+  },
+  {
+    name: 'archive_conversation',
+    description: 'Archive a conversation.',
     inputSchema: {
       type: 'object',
       required: ['conversation_id'],
@@ -80,6 +113,15 @@ export async function handleMessaging(name: string, args: Args): Promise<unknown
 
     case 'get_conversation':
       return api.bff(`/v3/conversations/me/${args['conversation_id'] as string}`);
+
+    case 'pre_approve_exchange':
+      return api.bffPatch(`/exchange/${args['conversation_id'] as string}/pre-approve`);
+
+    case 'archive_conversation':
+      return api.bffPatch(`/v1/conversations/${args['conversation_id'] as string}/archive`);
+
+    case 'get_exchange_request':
+      return api.bff(`/exchange/v2/${args['conversation_id'] as string}`);
 
     case 'get_messages':
       return api.bff('/v3/messages', { conversation_id: args['conversation_id'] as string });

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -98,17 +98,6 @@ export const searchTools: Tool[] = [
       },
     },
   },
-  {
-    name: 'get_user_profile',
-    description: "Get a member's public profile on HomeExchange.",
-    inputSchema: {
-      type: 'object',
-      required: ['user_id'],
-      properties: {
-        user_id: { type: 'string', description: 'Numeric user ID' },
-      },
-    },
-  },
 ];
 
 type Args = Record<string, unknown>;
@@ -164,9 +153,6 @@ export async function handleSearch(name: string, args: Args): Promise<unknown> {
       const limit = (args['limit'] as number | undefined) ?? 100;
       return api.bff('/search/saved-searches', { limit: String(limit) });
     }
-
-    case 'get_user_profile':
-      return api.bff(`/users/${args['user_id'] as string}`);
 
     default:
       throw new Error(`Unknown search tool: ${name}`);

--- a/src/tools/user.ts
+++ b/src/tools/user.ts
@@ -1,0 +1,56 @@
+import { type Tool } from '@modelcontextprotocol/sdk/types.js';
+import { api } from '../api';
+
+export const userTools: Tool[] = [
+  {
+    name: 'get_user_profile',
+    description: "Get a member's public profile on HomeExchange.",
+    inputSchema: {
+      type: 'object',
+      required: ['user_id'],
+      properties: {
+        user_id: { type: 'string', description: 'Numeric user ID' },
+      },
+    },
+  },
+  {
+    name: 'get_user_achievements',
+    description: "Get achievements for a HomeExchange member.",
+    inputSchema: {
+      type: 'object',
+      required: ['user_id'],
+      properties: {
+        user_id: { type: 'string', description: 'Numeric user ID' },
+      },
+    },
+  },
+  {
+    name: 'get_user_ratings',
+    description: "Get ratings left for a HomeExchange member.",
+    inputSchema: {
+      type: 'object',
+      required: ['user_id'],
+      properties: {
+        user_id: { type: 'string', description: 'Numeric user ID' },
+      },
+    },
+  },
+];
+
+type Args = Record<string, unknown>;
+
+export async function handleUser(name: string, args: Args): Promise<unknown> {
+  switch (name) {
+    case 'get_user_profile':
+      return api.get(`/v1/users/${args['user_id'] as string}`);
+
+    case 'get_user_achievements':
+      return api.get(`/v1/achievement/${args['user_id'] as string}`);
+
+    case 'get_user_ratings':
+      return api.get(`/v1/ratings/${args['user_id'] as string}`);
+
+    default:
+      throw new Error(`Unknown user tool: ${name}`);
+  }
+}


### PR DESCRIPTION
Hello, thank you for making this MCP, I have started using it and added some features.

## New tools

### Messaging (`src/tools/messaging.ts`)
- `get_messages` — fetch all messages of a conversation (`GET /v3/messages?conversation_id=...`)
- `get_exchange_request` — get exchange request details for a conversation (`GET /exchange/v2/:id`)
- `pre_approve_exchange` — pre-approve an exchange request (`PATCH /exchange/:id/pre-approve`)
- `archive_conversation` — archive a conversation (`PATCH /v1/conversations/:id/archive`)

### User (`src/tools/user.ts`) — new file
- `get_user_profile` — get a member's public profile (`GET /v1/users/:id`)
- `get_user_ratings` — get ratings for a member (`GET /v1/ratings/:id`)
- `get_user_achievements` — get achievements for a member (`GET /v1/achievement/:id`)

User tools were extracted from `search.ts` into a dedicated `user.ts` module for clarity.

## Other
- Added `bffPatch` method to `src/api.ts` to support PATCH requests on the BFF.
- Fixed `get_conversation` URL (was missing `/me/` segment).


BEGIN_COMMIT_OVERRIDE
feat: add messaging and user tools, contributed by @courentin
END_COMMIT_OVERRIDE
