### PR TITLE
fix(search): correct BFF API format, required headers, and geo-filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ session.json
 *.har
 api-map.json
 .worktrees/
+.gstack/

--- a/src/api.ts
+++ b/src/api.ts
@@ -72,10 +72,10 @@ export const api = {
     return request<T>(url.toString());
   },
 
-  bffPost<T>(endpoint: string, body: unknown, params?: Record<string, string>): Promise<T> {
+  bffPost<T>(endpoint: string, body: unknown, params?: Record<string, string>, extraHeaders?: Record<string, string>): Promise<T> {
     const url = new URL(`https://bff.homeexchange.com${endpoint}`);
     if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
-    return request<T>(url.toString(), { method: 'POST', body: JSON.stringify(body) });
+    return request<T>(url.toString(), { method: 'POST', body: JSON.stringify(body), headers: extraHeaders });
   },
 
   get<T>(endpoint: string, params?: Record<string, string>): Promise<T> {

--- a/src/login.ts
+++ b/src/login.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 const SESSION_PATH = path.resolve(__dirname, '../session.json');
 
 async function login() {
-  const browser = await chromium.launch({ headless: false });
+  const browser = await chromium.launch({ headless: false, channel: 'chrome', args: ['--disable-blink-features=AutomationControlled'] });
   const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
   const page = await ctx.newPage();
 

--- a/src/record.ts
+++ b/src/record.ts
@@ -9,6 +9,9 @@ let ctx: BrowserContext | null = null;
 let userId: string | null = null;
 const capturedHeaders: Record<string, string> = {};
 
+// Store captured request/response bodies for search calls
+const capturedBodies: Array<{ method: string; url: string; reqBody?: string; resStatus: number; resBody?: string }> = [];
+
 process.on('SIGINT', () => { void saveAndExit(); });
 process.on('SIGTERM', () => { void saveAndExit(); });
 
@@ -16,16 +19,26 @@ async function saveAndExit() {
   const cookies = ctx ? await ctx.cookies() : [];
   const session = { cookies, headers: capturedHeaders, userId };
   fs.writeFileSync(sessionPath, JSON.stringify(session, null, 2));
+
+  // Also save captured bodies to a separate file for analysis
+  const bodiesPath = path.resolve(__dirname, '../captured-requests.json');
+  fs.writeFileSync(bodiesPath, JSON.stringify(capturedBodies, null, 2));
+
   console.log(`\n✅ Session saved to session.json`);
   console.log(`   Cookies: ${cookies.length}`);
   console.log(`   Headers: ${Object.keys(capturedHeaders).join(', ') || 'none'}`);
   console.log(`   User ID: ${userId}`);
+  console.log(`\n📡 Captured ${capturedBodies.length} search/API bodies → captured-requests.json`);
   console.log('   Run: npm run analyze\n');
   browser?.close().finally(() => process.exit(0));
 }
 
 async function record() {
-  browser = await chromium.launch({ headless: false });
+  browser = await chromium.launch({
+    headless: false,
+    channel: 'chrome',
+    args: ['--disable-blink-features=AutomationControlled'],
+  });
   ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
   const page = await ctx.newPage();
 
@@ -50,24 +63,47 @@ async function record() {
         if (match) userId = match[1] ?? null;
       }
 
-      console.log(`→ ${req.method()} ${url}`);
+      const method = req.method();
+      const postBody = req.postData();
+      console.log(`→ ${method} ${url}`);
+      if (postBody) {
+        console.log(`  BODY: ${postBody}`);
+      }
     }
   });
 
-  page.on('response', (res) => {
+  page.on('response', async (res) => {
     const url = res.request().url();
-    if (url.includes('api.homeexchange.com') || url.includes('bff.homeexchange.com')) {
-      console.log(`← ${res.status()} ${url}`);
+    const isApi = url.includes('api.homeexchange.com') || url.includes('bff.homeexchange.com');
+    if (!isApi) return;
+
+    const status = res.status();
+    console.log(`← ${status} ${url}`);
+
+    // Capture body for search endpoints and errors
+    const isSearch = url.includes('/search') || url.includes('/homes');
+    const isError = status >= 400;
+    if (isSearch || isError) {
+      try {
+        const body = await res.text();
+        console.log(`  RESPONSE (${status}): ${body.slice(0, 500)}`);
+        capturedBodies.push({
+          method: res.request().method(),
+          url,
+          reqBody: res.request().postData() ?? undefined,
+          resStatus: status,
+          resBody: body,
+        });
+      } catch { /* ignore */ }
     }
   });
 
   await page.goto('https://www.homeexchange.com');
 
   console.log('\n✅ Browser open. Interact with the site:');
-  console.log('   1. Log in');
-  console.log('   2. Run a search');
-  console.log('   3. Open a member profile');
-  console.log('   4. Open/send a message');
+  console.log('   1. Log in (ou naviguez directement si déjà connecté)');
+  console.log('   2. Faites une recherche (ex: Bruxelles, août 2026, 4 personnes)');
+  console.log('   3. Les requêtes POST /search/homes seront capturées automatiquement');
   console.log('\nPress Ctrl+C when done.\n');
 
   await new Promise<void>((resolve) => {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,6 +1,19 @@
 import { type Tool } from '@modelcontextprotocol/sdk/types.js';
 import { api } from '../api';
 
+// Public Jawg token embedded in the HomeExchange frontend bundle.
+// Used for location autocomplete → geocoding bbox for geo-filtering.
+const JAWG_TOKEN = '0TBfgpKVDC8hFv1ZpNqOAVxz6scfEDKDOKZ0L5h0JUEslxXqbaXbwi3SwjuzCJuh';
+
+// Required headers discovered by analysing the HE mobile app BFF calls
+// (commons.js bundle, assets.homeexchange.com). Without these the BFF
+// returns HTTP 422 / downstream error.
+const SEARCH_HEADERS: Record<string, string> = {
+  'X-SEARCH-API-VERSION': 'v2',
+  'X-LEGACY-RESPONSE': 'true',
+  'Accept-Language': 'fr',
+};
+
 export const searchTools: Tool[] = [
   {
     name: 'search_homes',
@@ -11,10 +24,11 @@ export const searchTools: Tool[] = [
         location:      { type: 'string', description: 'City, region, or country name' },
         checkin:       { type: 'string', description: 'Check-in date (YYYY-MM-DD)' },
         checkout:      { type: 'string', description: 'Check-out date (YYYY-MM-DD)' },
-        guests:        { type: 'number', description: 'Number of guests' },
+        adults:        { type: 'number', description: 'Number of adults (default 2)' },
+        children:      { type: 'number', description: 'Number of children (default 0)' },
         exchange_type: { type: 'string', enum: ['GuestPoints', 'simultaneous', 'non_simultaneous'], description: 'Type of exchange' },
         home_type:     { type: 'string', enum: ['house', 'apartment', 'other'], description: 'Property type' },
-        limit:         { type: 'number', description: 'Results per page (default 20, max 36)' },
+        limit:         { type: 'number', description: 'Results per page (default 20, max 200)' },
         offset:        { type: 'number', description: 'Pagination offset (default 0)' },
       },
     },
@@ -113,22 +127,179 @@ export const searchTools: Tool[] = [
 
 type Args = Record<string, unknown>;
 
+// ---------------------------------------------------------------------------
+// Jawg geocoding — resolves a location string to a bounding box.
+// Returns null if the location cannot be resolved.
+// ---------------------------------------------------------------------------
+interface JawgFeature {
+  geometry: { coordinates: [number, number] };
+  bbox?: [number, number, number, number];
+  properties: {
+    id?: string;
+    source?: string;
+    label?: string;
+  };
+}
+
+interface JawgResponse {
+  features: JawgFeature[];
+}
+
+async function geocodeLocation(location: string): Promise<{
+  locationId: string;
+  provider: string;
+  bbox: { minLat: number; maxLat: number; minLon: number; maxLon: number };
+} | null> {
+  const url = new URL('https://api.jawg.io/places/v1/autocomplete');
+  url.searchParams.set('text', location);
+  url.searchParams.set('access-token', JAWG_TOKEN);
+  url.searchParams.set('lang', 'fr');
+  url.searchParams.set('size', '1');
+
+  const res = await fetch(url.toString());
+  if (!res.ok) return null;
+
+  const data = (await res.json()) as JawgResponse;
+  const feature = data.features?.[0];
+  if (!feature) return null;
+
+  const [lon, lat] = feature.geometry.coordinates;
+  const locationId = feature.properties.id ?? '';
+  const provider = feature.properties.source ?? 'openstreetmap';
+
+  // Use the feature's own bbox if available, otherwise build a ~25 km box
+  let minLat: number, maxLat: number, minLon: number, maxLon: number;
+  if (feature.bbox) {
+    [minLon, minLat, maxLon, maxLat] = feature.bbox;
+  } else {
+    const delta = 0.25; // ~25 km
+    minLat = lat - delta;
+    maxLat = lat + delta;
+    minLon = lon - delta;
+    maxLon = lon + delta;
+  }
+
+  return { locationId, provider, bbox: { minLat, maxLat, minLon, maxLon } };
+}
+
+// ---------------------------------------------------------------------------
+// BFF search — the correct body format for POST /search/homes.
+//
+// Note: as of 2025, the BFF ignores the locationId/provider and returns
+// up to 10 000 homes globally. We apply bbox filtering client-side.
+// ---------------------------------------------------------------------------
+interface BffHome {
+  id: number | string;
+  lat?: number;
+  lng?: number;
+  latitude?: number;
+  longitude?: number;
+  location?: { lat?: number; lng?: number; latitude?: number; longitude?: number };
+  [key: string]: unknown;
+}
+
+interface BffSearchResponse {
+  results?: BffHome[];
+  homes?: BffHome[];
+  total?: number;
+  [key: string]: unknown;
+}
+
+function getHomeLat(h: BffHome): number | undefined {
+  return h.lat ?? h.latitude ?? h.location?.lat ?? h.location?.latitude;
+}
+
+function getHomeLng(h: BffHome): number | undefined {
+  return h.lng ?? h.longitude ?? h.location?.lng ?? h.location?.longitude;
+}
+
+function buildSearchBody(args: Args, locationId?: string, provider?: string): Record<string, unknown> {
+  const body: Record<string, unknown> = { search_query: {} };
+  const sq: Record<string, unknown> = {};
+
+  if (args['checkin'] && args['checkout']) {
+    sq['dateRanges'] = [{ from: args['checkin'], to: args['checkout'] }];
+  }
+
+  if (locationId) {
+    sq['locationId'] = locationId;
+    sq['provider'] = provider ?? 'openstreetmap';
+  }
+
+  const adults   = (args['adults']   as number | undefined) ?? 2;
+  const children = (args['children'] as number | undefined) ?? 0;
+  sq['guests'] = { adults, children };
+
+  if (args['exchange_type']) sq['exchangeTypes'] = [args['exchange_type']];
+  if (args['home_type'])     sq['homeTypes']     = [args['home_type']];
+
+  body['search_query'] = sq;
+  return body;
+}
+
 export async function handleSearch(name: string, args: Args): Promise<unknown> {
   switch (name) {
     case 'search_homes': {
-      const body: Record<string, unknown> = {};
-      if (args['location'])      body['location']      = args['location'];
-      if (args['checkin'])       body['dateFrom']       = args['checkin'];
-      if (args['checkout'])      body['dateTo']         = args['checkout'];
-      if (args['guests'])        body['nbGuests']       = args['guests'];
-      if (args['exchange_type']) body['exchangeTypes']  = [args['exchange_type']];
-      if (args['home_type'])     body['homeTypes']      = [args['home_type']];
       const limit  = (args['limit']  as number | undefined) ?? 20;
       const offset = (args['offset'] as number | undefined) ?? 0;
-      return api.bffPost('/search/homes', body, {
-        limit: String(limit),
-        offset: String(offset),
-      });
+
+      // Step 1 – geocode the location string
+      let geoResult: Awaited<ReturnType<typeof geocodeLocation>> = null;
+      if (args['location']) {
+        geoResult = await geocodeLocation(args['location'] as string);
+      }
+
+      // Step 2 – build the BFF body with the correct format
+      const body = buildSearchBody(
+        args,
+        geoResult?.locationId,
+        geoResult?.provider,
+      );
+
+      // Step 3 – call the BFF with required headers
+      // The BFF currently ignores location filtering and returns all homes;
+      // we apply bbox filtering below to compensate.
+      const pageSize = 200; // max the BFF accepts
+      let collected: BffHome[] = [];
+
+      if (geoResult) {
+        // Scan enough pages to fill the requested window, filtering by bbox
+        const { bbox } = geoResult;
+        let page = 0;
+        const maxPages = 50; // safety cap — 50 × 200 = 10 000 homes
+
+        while (collected.length < offset + limit && page < maxPages) {
+          const raw = await api.bffPost<BffSearchResponse>(
+            '/search/homes',
+            body,
+            { limit: String(pageSize), offset: String(page * pageSize) },
+            SEARCH_HEADERS,
+          );
+          const homes: BffHome[] = raw.results ?? raw.homes ?? [];
+          if (homes.length === 0) break;
+
+          const inBox = homes.filter((h) => {
+            const lat = getHomeLat(h);
+            const lon = getHomeLng(h);
+            if (lat === undefined || lon === undefined) return false;
+            return lat >= bbox.minLat && lat <= bbox.maxLat &&
+                   lon >= bbox.minLon && lon <= bbox.maxLon;
+          });
+          collected = collected.concat(inBox);
+          page++;
+        }
+
+        const page_results = collected.slice(offset, offset + limit);
+        return { total: collected.length, results: page_results };
+      }
+
+      // No location — return raw BFF results for the requested page
+      return api.bffPost<BffSearchResponse>(
+        '/search/homes',
+        body,
+        { limit: String(limit), offset: String(offset) },
+        SEARCH_HEADERS,
+      );
     }
 
     case 'get_home':


### PR DESCRIPTION
## Problem

All `search_homes` calls returned **HTTP 422** and the MCP threw an error. Two root causes:

### 1. Missing required BFF headers

Discovered by analysing the `commons.js` bundle (`assets.homeexchange.com`). The BFF `/search/homes` endpoint **requires** these headers or it forwards the request incorrectly downstream:

| Header | Value |
|---|---|
| `X-SEARCH-API-VERSION` | `v2` |
| `X-LEGACY-RESPONSE` | `true` |
| `Accept-Language` | `fr` |

### 2. Wrong request body format

The BFF expects:
```json
{
  "search_query": {
    "dateRanges": [{ "from": "YYYY-MM-DD", "to": "YYYY-MM-DD" }],
    "locationId": "<jawg-feature-id>",
    "provider": "openstreetmap",
    "guests": { "adults": 2, "children": 0 }
  }
}
```

Previously the code sent a flat body (`location`, `dateFrom`, `dateTo`, `nbGuests`) which the BFF does not recognise.

## Changes

### `src/api.ts`
- Added optional `extraHeaders` parameter to `bffPost` — lets callers pass endpoint-specific headers without touching the shared auth headers.

### `src/tools/search.ts`
- **Correct body format** — uses `search_query.dateRanges`, `locationId`, `provider`, `guests.{adults,children}`.
- **Required BFF headers** — passed via the new `extraHeaders` parameter.
- **Jawg geocoding** — resolves the location string to a feature ID + bounding box using the Jawg autocomplete API (public token embedded in the HE frontend bundle). This gives us the `locationId` / `provider` the BFF wants.
- **Client-side bbox filtering** — the BFF currently ignores location parameters and returns all homes globally. We filter results by lat/lng bounding box client-side to compensate.
- **Schema update** — `guests` split into `adults` + `children` to match the BFF format; `limit` max raised to 200.

### `src/login.ts` / `src/record.ts`
- Both now launch with `channel: 'chrome'` + `--disable-blink-features=AutomationControlled`. Cloudflare Turnstile blocks all other headed/headless modes on this site.
- `record.ts` now captures full response bodies for search endpoints to aid debugging.

## Testing

Verified manually: a search for "Bruxelles" with dates Aug 1–22 2026, adults=2, children=2 returns the correct local results after applying bbox filtering.