### PR TITLE
ci: handle fork pull requests without repository secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,11 @@ jobs:
         run: npm run check
 
       - name: SonarCloud scan
-        if: github.actor != 'dependabot[bot]'
+        # Repository secrets are intentionally unavailable to fork pull requests.
+        if: >-
+          github.actor != 'dependabot[bot]' &&
+          (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository)
         uses: SonarSource/sonarqube-scan-action@v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- keep the full local validation job for fork pull requests
- skip only SonarCloud when GitHub intentionally withholds repository secrets
- continue SonarCloud analysis for trusted branches and same-repository pull requests

## Why
PR #24 passes typecheck, lint, tests, coverage, build, production audit, and CodeQL, but CI attempts SonarCloud with an empty SONAR_TOKEN because it originates from a fork. Exposing secrets through pull_request_target would be unsafe.

## Validation
- npm run check
- npm run build
- actionlint .github/workflows/ci.yml
- git diff --check