### PR TITLE
ci: enforce conventional pull request titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+name: Pull request title
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  semantic-title:
+    name: Semantic pull request
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate Conventional Commit title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test

--- a/README.md
+++ b/README.md
@@ -364,7 +364,8 @@ Ideas, bug reports, and pull requests are welcome.
 
 1. Fork the repo and create a branch from `main`
 2. Make your changes — keep commits [conventional](https://www.conventionalcommits.org/) (`fix:`, `feat:`, `chore:` etc.)
-3. Open a pull request — CI must pass before merge
+3. Open a pull request with a conventional title, such as `feat: add calendar filtering` or `fix(api): handle expired sessions`
+4. Ensure all required checks pass before merge
 
 **Good first issues** are tagged [`good first issue`](https://github.com/osloer-industries/homeexchange-mcp/labels/good%20first%20issue) — start there if you're new to the codebase.
 
@@ -376,7 +377,9 @@ Ideas, bug reports, and pull requests are welcome.
 
 Release Please collects conventional commits on `main` into a release pull request. A maintainer reviews that pull request and merges it when the project is ready to publish. Merging it updates `CHANGELOG.md`, `package.json`, and `package-lock.json`, then creates the version tag and GitHub Release.
 
-Before `1.0.0`, `feat:` and breaking changes increase the minor version, while `fix:`, `perf:`, and `revert:` increase the patch version. The release workflow uses the `RELEASE_TOKEN` repository secret so its pull requests receive the normal required CI checks. That fine-grained token must have access only to this repository, permission to write contents and pull requests, and an expiration that complies with the organization policy.
+Before `1.0.0`, `feat:` and breaking changes increase the minor version, while `fix:`, `perf:`, and `revert:` increase the patch version. The release workflow consumes the organization Actions secret named `RELEASE_TOKEN` so its pull requests receive the normal required CI checks. Organization administrators must include this repository in the secret's selected-repository access policy. The underlying credential needs permission to write contents and pull requests, and an expiration that complies with organization policy.
+
+Pull request titles are validated against the Conventional Commits format. Squash merges use the validated title as the commit subject so Release Please can calculate the correct version and changelog entry.
 
 ---
 


### PR DESCRIPTION
## Summary

- validate PR titles against Conventional Commits for repository and fork contributions
- run with read-only pull request permission and without checking out contributor code
- pin the validation action to the immutable v6.1.1 commit
- document the title requirement and how squash titles feed Release Please
- clarify that RELEASE_TOKEN is supplied through the organization Actions secret

## Repository setting

Squash merges now use the validated PR title as the commit subject and the PR body as the commit body.

## Validation

- actionlint
- npm ci
- npm run check, 19 tests passed
- npm run build
- npm audit --json, 0 vulnerabilities