### PR TITLE
fix: satisfy quality gate for new tools

### DIFF
--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -1,0 +1,105 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const toolMocks = vi.hoisted(() => ({
+  handleSearch: vi.fn(),
+  handleMessaging: vi.fn(),
+  handleUser: vi.fn(),
+}));
+
+vi.mock('./tools/search', () => ({
+  searchTools: [{ name: 'search', description: 'Search', inputSchema: { type: 'object' } }],
+  handleSearch: toolMocks.handleSearch,
+}));
+vi.mock('./tools/messaging', () => ({
+  messagingTools: [{ name: 'message', description: 'Message', inputSchema: { type: 'object' } }],
+  handleMessaging: toolMocks.handleMessaging,
+}));
+vi.mock('./tools/user', () => ({
+  userTools: [{ name: 'user', description: 'User', inputSchema: { type: 'object' } }],
+  handleUser: toolMocks.handleUser,
+}));
+
+import {
+  allTools,
+  createServer,
+  handleToolCall,
+  listTools,
+  main,
+  reportFatal,
+} from './mcp';
+
+describe('MCP server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toolMocks.handleSearch.mockResolvedValue({ source: 'search' });
+    toolMocks.handleMessaging.mockResolvedValue({ source: 'messaging' });
+    toolMocks.handleUser.mockResolvedValue({ source: 'user' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists tools from every category', () => {
+    expect(allTools.map((tool) => tool.name)).toEqual(['search', 'message', 'user']);
+    expect(listTools()).toEqual({ tools: allTools });
+  });
+
+  it.each([
+    ['search', 'handleSearch', 'search'],
+    ['message', 'handleMessaging', 'messaging'],
+    ['user', 'handleUser', 'user'],
+  ] as const)('dispatches %s tools through %s', async (name, handler, source) => {
+    const args = { value: 1 };
+
+    await expect(handleToolCall(name, args)).resolves.toEqual({
+      content: [{ type: 'text', text: JSON.stringify({ source }, null, 2) }],
+    });
+    expect(toolMocks[handler]).toHaveBeenCalledWith(name, args);
+  });
+
+  it('returns MCP errors for unknown tools', async () => {
+    await expect(handleToolCall('unknown')).resolves.toEqual({
+      content: [{ type: 'text', text: 'Error: Unknown tool: unknown' }],
+      isError: true,
+    });
+  });
+
+  it('normalizes non-Error failures from handlers', async () => {
+    toolMocks.handleSearch.mockRejectedValueOnce('offline');
+
+    await expect(handleToolCall('search')).resolves.toEqual({
+      content: [{ type: 'text', text: 'Error: offline' }],
+      isError: true,
+    });
+  });
+
+  it('creates an MCP server with registered handlers', () => {
+    expect(createServer()).toBeInstanceOf(Server);
+  });
+
+  it('connects the server to its transport', async () => {
+    const server = createServer();
+    const connect = vi.spyOn(server, 'connect').mockResolvedValue();
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const transport = {} as Parameters<typeof main>[1];
+
+    await main(server, transport);
+
+    expect(connect).toHaveBeenCalledWith(transport);
+    expect(write).toHaveBeenCalledWith('HomeExchange MCP server running (stdio)\n');
+  });
+
+  it('reports fatal startup errors and exits', () => {
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process exited');
+    }) as typeof process.exit);
+
+    expect(() => reportFatal(new Error('broken'))).toThrow('process exited');
+
+    expect(write).toHaveBeenCalledWith('Fatal: Error: broken\n');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -9,32 +9,28 @@ import { searchTools, handleSearch } from './tools/search';
 import { messagingTools, handleMessaging } from './tools/messaging';
 import { userTools, handleUser } from './tools/user';
 
-const ALL_TOOLS = [...searchTools, ...messagingTools, ...userTools];
+export const allTools = [...searchTools, ...messagingTools, ...userTools];
 const SEARCH_NAMES = new Set(searchTools.map((t) => t.name));
 const MESSAGING_NAMES = new Set(messagingTools.map((t) => t.name));
 const USER_NAMES = new Set(userTools.map((t) => t.name));
 
-const server = new Server(
-  { name: 'homeexchange', version: '1.0.0' },
-  { capabilities: { tools: {} } }
-);
+export function listTools() {
+  return { tools: allTools };
+}
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: ALL_TOOLS,
-}));
-
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const { name, arguments: args = {} } = req.params;
-
+export async function handleToolCall(
+  name: string,
+  args: Record<string, unknown> = {}
+) {
   try {
     let result: unknown;
 
     if (SEARCH_NAMES.has(name)) {
-      result = await handleSearch(name, args as Record<string, unknown>);
+      result = await handleSearch(name, args);
     } else if (MESSAGING_NAMES.has(name)) {
-      result = await handleMessaging(name, args as Record<string, unknown>);
+      result = await handleMessaging(name, args);
     } else if (USER_NAMES.has(name)) {
-      result = await handleUser(name, args as Record<string, unknown>);
+      result = await handleUser(name, args);
     } else {
       throw new Error(`Unknown tool: ${name}`);
     }
@@ -49,15 +45,36 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       isError: true,
     };
   }
-});
+}
 
-async function main() {
-  const transport = new StdioServerTransport();
+export function createServer(): Server {
+  const server = new Server(
+    { name: 'homeexchange', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => listTools());
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args = {} } = req.params;
+    return handleToolCall(name, args as Record<string, unknown>);
+  });
+
+  return server;
+}
+
+export async function main(
+  server: Server = createServer(),
+  transport: StdioServerTransport = new StdioServerTransport()
+) {
   await server.connect(transport);
   process.stderr.write('HomeExchange MCP server running (stdio)\n');
 }
 
-main().catch((err) => {
+export function reportFatal(err: unknown): never {
   process.stderr.write(`Fatal: ${String(err)}\n`);
   process.exit(1);
-});
+}
+
+if (process.argv[1] === __filename) {
+  main().catch(reportFatal);
+}

--- a/src/tools/messaging.test.ts
+++ b/src/tools/messaging.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleMessaging, messagingTools } from './messaging';
+
+const apiMock = vi.hoisted(() => ({
+  bff: vi.fn(),
+  bffPatch: vi.fn(),
+  bffPost: vi.fn(),
+}));
+
+vi.mock('../api', () => ({ api: apiMock }));
+
+describe('messaging tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.bff.mockResolvedValue({ ok: true });
+    apiMock.bffPatch.mockResolvedValue({ ok: true });
+    apiMock.bffPost.mockResolvedValue({ ok: true });
+  });
+
+  it('defines all messaging tools with their required string fields', () => {
+    expect(messagingTools.map((tool) => tool.name)).toEqual([
+      'list_conversations',
+      'get_conversation',
+      'send_message',
+      'get_exchange_request',
+      'get_messages',
+      'pre_approve_exchange',
+      'archive_conversation',
+      'start_conversation',
+    ]);
+    expect(messagingTools.find((tool) => tool.name === 'send_message')?.inputSchema.required)
+      .toEqual(['conversation_id', 'text']);
+  });
+
+  it('lists conversations with defaults and an optional cursor', async () => {
+    await handleMessaging('list_conversations', {});
+    await handleMessaging('list_conversations', {
+      filter: 'UNANSWERED',
+      limit: 5,
+      after: 'next-page',
+    });
+
+    expect(apiMock.bff).toHaveBeenNthCalledWith(
+      1,
+      '/v3/conversations/me',
+      { filter: 'ALL', first: '20' }
+    );
+    expect(apiMock.bff).toHaveBeenNthCalledWith(
+      2,
+      '/v3/conversations/me',
+      { filter: 'UNANSWERED', first: '5', after: 'next-page' }
+    );
+  });
+
+  it('gets conversation, exchange, and message details', async () => {
+    await handleMessaging('get_conversation', { conversation_id: '123' });
+    await handleMessaging('get_exchange_request', { conversation_id: '123' });
+    await handleMessaging('get_messages', { conversation_id: '123' });
+
+    expect(apiMock.bff).toHaveBeenNthCalledWith(1, '/v3/conversations/me/123');
+    expect(apiMock.bff).toHaveBeenNthCalledWith(2, '/exchange/v2/123');
+    expect(apiMock.bff).toHaveBeenNthCalledWith(
+      3,
+      '/v3/messages',
+      { conversation_id: '123' }
+    );
+  });
+
+  it('pre-approves and archives conversations', async () => {
+    await handleMessaging('pre_approve_exchange', { conversation_id: '123' });
+    await handleMessaging('archive_conversation', { conversation_id: '123' });
+
+    expect(apiMock.bffPatch).toHaveBeenNthCalledWith(1, '/exchange/123/pre-approve');
+    expect(apiMock.bffPatch).toHaveBeenNthCalledWith(2, '/v1/conversations/123/archive');
+  });
+
+  it('sends messages to existing and new conversations', async () => {
+    await handleMessaging('send_message', { conversation_id: '123', text: 'Hello' });
+    await handleMessaging('start_conversation', { home_id: '456', text: 'Hi' });
+
+    expect(apiMock.bffPost).toHaveBeenNthCalledWith(1, '/v1/messages', {
+      content: 'Hello',
+      conversation: 123,
+    });
+    expect(apiMock.bffPost).toHaveBeenNthCalledWith(2, '/v3/conversations', {
+      homeId: '456',
+      message: { text: 'Hi' },
+    });
+  });
+
+  it('rejects unknown messaging tools', async () => {
+    await expect(handleMessaging('unknown', {})).rejects.toThrow(
+      'Unknown messaging tool: unknown'
+    );
+  });
+});

--- a/src/tools/messaging.ts
+++ b/src/tools/messaging.ts
@@ -1,5 +1,6 @@
 import { type Tool } from '@modelcontextprotocol/sdk/types.js';
 import { api } from '../api';
+import { requiredStringTool } from './tool-schema';
 
 export const messagingTools: Tool[] = [
   {
@@ -18,85 +19,41 @@ export const messagingTools: Tool[] = [
       },
     },
   },
-  {
-    name: 'get_conversation',
-    description: 'Get extended information about a conversation.',
-    inputSchema: {
-      type: 'object',
-      required: ['conversation_id'],
-      properties: {
-        conversation_id: { type: 'string', description: 'Conversation ID' },
-      },
-    },
-  },
-  {
-    name: 'send_message',
-    description: 'Send a message in an existing conversation.',
-    inputSchema: {
-      type: 'object',
-      required: ['conversation_id', 'text'],
-      properties: {
-        conversation_id: { type: 'string', description: 'Conversation ID' },
-        text: { type: 'string', description: 'Message text to send' },
-      },
-    },
-  },
-  {
-    name: 'get_exchange_request',
-    description: 'Get exchange request details for a conversation.',
-    inputSchema: {
-      type: 'object',
-      required: ['conversation_id'],
-      properties: {
-        conversation_id: { type: 'string', description: 'Conversation ID' },
-      },
-    },
-  },
-  {
-    name: 'get_messages',
-    description: 'Get all messages of a conversation.',
-    inputSchema: {
-      type: 'object',
-      required: ['conversation_id'],
-      properties: {
-        conversation_id: { type: 'string', description: 'Conversation ID' },
-      },
-    },
-  },
-  {
-    name: 'pre_approve_exchange',
-    description: 'Pre-approve an exchange request.',
-    inputSchema: {
-      type: 'object',
-      required: ['conversation_id'],
-      properties: {
-        conversation_id: { type: 'string', description: 'Conversation ID' },
-      },
-    },
-  },
-  {
-    name: 'archive_conversation',
-    description: 'Archive a conversation.',
-    inputSchema: {
-      type: 'object',
-      required: ['conversation_id'],
-      properties: {
-        conversation_id: { type: 'string', description: 'Conversation ID' },
-      },
-    },
-  },
-  {
-    name: 'start_conversation',
-    description: 'Start a new conversation with a member about their home.',
-    inputSchema: {
-      type: 'object',
-      required: ['home_id', 'text'],
-      properties: {
-        home_id: { type: 'string', description: 'The home you are enquiring about' },
-        text: { type: 'string', description: 'Opening message' },
-      },
-    },
-  },
+  requiredStringTool(
+    'get_conversation',
+    'Get extended information about a conversation.',
+    { conversation_id: 'Conversation ID' }
+  ),
+  requiredStringTool(
+    'send_message',
+    'Send a message in an existing conversation.',
+    { conversation_id: 'Conversation ID', text: 'Message text to send' }
+  ),
+  requiredStringTool(
+    'get_exchange_request',
+    'Get exchange request details for a conversation.',
+    { conversation_id: 'Conversation ID' }
+  ),
+  requiredStringTool(
+    'get_messages',
+    'Get all messages of a conversation.',
+    { conversation_id: 'Conversation ID' }
+  ),
+  requiredStringTool(
+    'pre_approve_exchange',
+    'Pre-approve an exchange request.',
+    { conversation_id: 'Conversation ID' }
+  ),
+  requiredStringTool(
+    'archive_conversation',
+    'Archive a conversation.',
+    { conversation_id: 'Conversation ID' }
+  ),
+  requiredStringTool(
+    'start_conversation',
+    'Start a new conversation with a member about their home.',
+    { home_id: 'The home you are enquiring about', text: 'Opening message' }
+  ),
 ];
 
 type Args = Record<string, unknown>;

--- a/src/tools/tool-schema.ts
+++ b/src/tools/tool-schema.ts
@@ -1,0 +1,25 @@
+import { type Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export function requiredStringTool(
+  name: string,
+  description: string,
+  fields: Record<string, string>
+): Tool {
+  const required = Object.keys(fields);
+  const properties = Object.fromEntries(
+    Object.entries(fields).map(([field, fieldDescription]) => [
+      field,
+      { type: 'string', description: fieldDescription },
+    ])
+  );
+
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: 'object',
+      required,
+      properties,
+    },
+  };
+}

--- a/src/tools/user.test.ts
+++ b/src/tools/user.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleUser, userTools } from './user';
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock('../api', () => ({ api: apiMock }));
+
+describe('user tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.get.mockResolvedValue({ ok: true });
+  });
+
+  it('defines all user tools with a required user ID', () => {
+    expect(userTools.map((tool) => tool.name)).toEqual([
+      'get_user_profile',
+      'get_user_achievements',
+      'get_user_ratings',
+    ]);
+    for (const tool of userTools) {
+      expect(tool.inputSchema.required).toEqual(['user_id']);
+    }
+  });
+
+  it.each([
+    ['get_user_profile', '/v1/users/123'],
+    ['get_user_achievements', '/v1/achievement/123'],
+    ['get_user_ratings', '/v1/ratings/123'],
+  ])('routes %s to %s', async (name, endpoint) => {
+    await expect(handleUser(name, { user_id: '123' })).resolves.toEqual({ ok: true });
+    expect(apiMock.get).toHaveBeenCalledWith(endpoint);
+  });
+
+  it('rejects unknown user tools', async () => {
+    await expect(handleUser('unknown', {})).rejects.toThrow('Unknown user tool: unknown');
+  });
+});

--- a/src/tools/user.ts
+++ b/src/tools/user.ts
@@ -1,40 +1,23 @@
 import { type Tool } from '@modelcontextprotocol/sdk/types.js';
 import { api } from '../api';
+import { requiredStringTool } from './tool-schema';
 
 export const userTools: Tool[] = [
-  {
-    name: 'get_user_profile',
-    description: "Get a member's public profile on HomeExchange.",
-    inputSchema: {
-      type: 'object',
-      required: ['user_id'],
-      properties: {
-        user_id: { type: 'string', description: 'Numeric user ID' },
-      },
-    },
-  },
-  {
-    name: 'get_user_achievements',
-    description: "Get achievements for a HomeExchange member.",
-    inputSchema: {
-      type: 'object',
-      required: ['user_id'],
-      properties: {
-        user_id: { type: 'string', description: 'Numeric user ID' },
-      },
-    },
-  },
-  {
-    name: 'get_user_ratings',
-    description: "Get ratings left for a HomeExchange member.",
-    inputSchema: {
-      type: 'object',
-      required: ['user_id'],
-      properties: {
-        user_id: { type: 'string', description: 'Numeric user ID' },
-      },
-    },
-  },
+  requiredStringTool(
+    'get_user_profile',
+    "Get a member's public profile on HomeExchange.",
+    { user_id: 'Numeric user ID' }
+  ),
+  requiredStringTool(
+    'get_user_achievements',
+    'Get achievements for a HomeExchange member.',
+    { user_id: 'Numeric user ID' }
+  ),
+  requiredStringTool(
+    'get_user_ratings',
+    'Get ratings left for a HomeExchange member.',
+    { user_id: 'Numeric user ID' }
+  ),
 ];
 
 type Args = Record<string, unknown>;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,7 +6,14 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['src/api.ts', 'src/security.ts'],
+      include: [
+        'src/api.ts',
+        'src/mcp.ts',
+        'src/security.ts',
+        'src/tools/messaging.ts',
+        'src/tools/tool-schema.ts',
+        'src/tools/user.ts',
+      ],
       thresholds: {
         branches: 60,
         functions: 80,


### PR DESCRIPTION
## Summary

- collect coverage for the messaging, user, MCP, and shared schema modules
- add focused routing, schema, error-handling, and server lifecycle tests
- replace repeated JSON schema blocks with one typed helper
- preserve MCP startup behavior while making dispatch and lifecycle paths testable

## Why

The main-branch SonarCloud gate reported 58.1% new-code coverage and 25.7% new-code duplication after the messaging and user tools merged. The original Vitest configuration collected coverage only from api.ts and security.ts, and the new tool schemas repeated the same structures.

## Local validation

- npm run check, 39 tests passed
- 93.93% line coverage
- 88.13% statement coverage
- 80% branch coverage
- 83.33% function coverage
- npm run build
- npm audit --json, 0 vulnerabilities
- actionlint

The required SonarCloud Code Analysis check must pass before merge.