### PR TITLE
fix: reliably save local HomeExchange sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent Policy
+
+## HomeExchange MCP safety
+
+This repository can access private HomeExchange account data. Treat all session
+files, cookies, bearer tokens, member data, messages, and exchange details as
+sensitive. Never print, commit, upload, or copy them into issues or pull
+requests.
+
+### Approval-required tools
+
+An agent must obtain explicit, per-call user approval immediately before it
+invokes any tool that changes remote HomeExchange state:
+
+- `send_message`
+- `start_conversation`
+- `pre_approve_exchange`
+- `archive_conversation`
+- `add_favorite`
+- `remove_favorite`
+
+Do not treat an earlier general request, a test plan, or tool availability as
+approval. Before calling one of these tools, state the exact action and target,
+and wait for the user to confirm it.
+
+### Read-only validation
+
+Read-only tools may be used for validation, but return only the minimum
+necessary summary. Redact names, addresses, message contents, booking dates,
+and identifiers unless the user specifically needs them.

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,9 +1,16 @@
 import { chromium } from 'playwright';
 import * as fs from 'fs';
 import * as path from 'path';
+import { clearInterval, clearTimeout, setInterval, setTimeout } from 'node:timers';
 import { isHomeExchangeHostname } from './security';
 
 const SESSION_PATH = path.resolve(__dirname, '../session.json');
+
+interface SessionCookie {
+  name: string;
+  value: string;
+  domain: string;
+}
 
 async function login() {
   const browser = await chromium.launch({ headless: false });
@@ -12,9 +19,51 @@ async function login() {
 
   let token: string | null = null;
   let userId: string | null = null;
+  let cookies: SessionCookie[] = [];
+  let saving = false;
+  let complete: (() => void) | undefined;
+  let autoSaveTimer: ReturnType<typeof setTimeout> | undefined;
 
   console.log('\n🔐 HomeExchange Login\n');
-  console.log('   Log in to your account, then press Ctrl+C (or close the browser).\n');
+  console.log('   Log in to your account. Your session is saved automatically once sign-in is detected.\n');
+  console.log('   If it is not saved automatically, return here and press Enter or Ctrl+C.\n');
+
+  const refreshCookies = async () => {
+    try {
+      cookies = (await ctx.cookies())
+        .filter((cookie) => isHomeExchangeHostname(cookie.domain))
+        .map(({ name, value, domain }) => ({ name, value, domain }));
+    } catch {
+      // The browser may already be closed. Keep the most recently captured cookies.
+    }
+  };
+
+  const save = async () => {
+    if (saving) return;
+    saving = true;
+    if (autoSaveTimer) clearTimeout(autoSaveTimer);
+    await refreshCookies();
+
+    const session = { token, cookies, userId };
+    fs.writeFileSync(SESSION_PATH, JSON.stringify(session, null, 2));
+    console.log('\n💾 Session saved to session.json');
+    console.log(`   Cookies: ${cookies.length}`);
+    console.log(`   User ID: ${userId ?? 'unknown'}`);
+    console.log('\n   Run: npm run mcp\n');
+
+    if (browser.isConnected()) await browser.close();
+    process.stdin.pause();
+    complete?.();
+  };
+
+  const scheduleAutoSave = async () => {
+    if (saving || autoSaveTimer || !userId) return;
+    await refreshCookies();
+    if (cookies.length === 0) return;
+
+    console.log('✅ Signed-in session detected. Saving local session...');
+    autoSaveTimer = setTimeout(() => { void save(); }, 1_000);
+  };
 
   page.on('request', (req) => {
     const url = new URL(req.url());
@@ -24,6 +73,7 @@ async function login() {
     if (auth && auth !== 'Bearer undefined' && !token) {
       token = auth;
       console.log('✅ Auth token captured.');
+      void scheduleAutoSave();
     }
 
     if (!userId) {
@@ -31,28 +81,22 @@ async function login() {
       if (match?.[1]) {
         userId = match[1];
         console.log(`✅ User ID: ${userId}`);
+        void scheduleAutoSave();
       }
     }
   });
-
-  const save = async () => {
-    const cookies = await ctx.cookies();
-    const session = { token, cookies, userId };
-    fs.writeFileSync(SESSION_PATH, JSON.stringify(session, null, 2));
-    console.log(`\n💾 Session saved to session.json`);
-    console.log(`   Token:   ${token ? token.slice(0, 40) + '...' : 'none'}`);
-    console.log(`   Cookies: ${cookies.length}`);
-    console.log(`   User ID: ${userId ?? 'unknown'}`);
-    console.log('\n   Run: npm run mcp\n');
-    await browser.close();
-    process.exit(0);
-  };
 
   process.on('SIGINT', () => { void save(); });
   browser.on('disconnected', () => { void save(); });
 
   await page.goto('https://www.homeexchange.com');
-  await new Promise<void>(() => {}); // keep alive until signal
+  await refreshCookies();
+  const cookieRefresh = setInterval(() => { void refreshCookies(); }, 1_000);
+
+  process.stdin.resume();
+  process.stdin.once('data', () => { void save(); });
+  await new Promise<void>((resolve) => { complete = resolve; });
+  clearInterval(cookieRefresh);
 }
 
 login().catch(console.error);


### PR DESCRIPTION
## Summary
- save only HomeExchange cookies and never print token material
- save automatically after authenticated user detection, with Enter or Ctrl+C fallback
- document explicit approval requirements for state-changing MCP tools

## Validation
- npm run check
- npm run build
- manual local MCP startup validated with an authenticated session

The local session file and machine-specific Codex configuration are intentionally excluded.